### PR TITLE
Fix compilation with clang-11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ $RECYCLE.BIN/
 # b64 encoding script
 scripts/b64encode
 
+# C-encoded image files.
+src/Image_*.[ch]
+
 # Build directory
 build/

--- a/src/Images.c
+++ b/src/Images.c
@@ -1,6 +1,13 @@
 
 #include "Images.h"
 
+SDL_Texture *IMG_BOX;
+SDL_Texture *IMG_BOXTARGET;
+SDL_Texture *IMG_FREE;
+SDL_Texture *IMG_PLAYER;
+SDL_Texture *IMG_TARGET;
+SDL_Texture *IMG_WALL;
+
 /**
  * @brief Number of different images in this game.
  */

--- a/src/Images.h
+++ b/src/Images.h
@@ -17,12 +17,12 @@
 #include "Image_wall.h"
 #include "Levels.h"
 
-SDL_Texture *IMG_BOX;
-SDL_Texture *IMG_BOXTARGET;
-SDL_Texture *IMG_FREE;
-SDL_Texture *IMG_PLAYER;
-SDL_Texture *IMG_TARGET;
-SDL_Texture *IMG_WALL;
+extern SDL_Texture *IMG_BOX;
+extern SDL_Texture *IMG_BOXTARGET;
+extern SDL_Texture *IMG_FREE;
+extern SDL_Texture *IMG_PLAYER;
+extern SDL_Texture *IMG_TARGET;
+extern SDL_Texture *IMG_WALL;
 
 void deinitialize_images();
 

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -7,7 +7,7 @@
 
 #include "View.h"
 
-bool MENU_SHOWN;
+extern bool MENU_SHOWN;
 
 void show_menu();
 


### PR DESCRIPTION
* Global variables in headers need to be externed, otherwhise they will be defined in multiple object files and cause duplicates in the linking step
* Update .gitignore to exclude embedded image data files (src/Image_*.[ch])